### PR TITLE
Add stdout Capability

### DIFF
--- a/R/bunyanLog.R
+++ b/R/bunyanLog.R
@@ -128,11 +128,14 @@ function(msg, level, req, res, version) {
     }
 
     ######
-    #FILE logging
     if (bunyan_globals$logname != "") {
+      #FILE logging
       cat(logline, file=bunyan_globals$log_con, sep="\n", append=TRUE)
       # Windows likes to be flushed
       flush(bunyan_globals$log_con)
+    } else {
+      #STDOUT logging
+      cat(logline, file=bunyan_globals$log_con, sep="\n")
     }
 
     #####

--- a/R/bunyanSetLog.R
+++ b/R/bunyanSetLog.R
@@ -74,8 +74,10 @@ function(level, logpath, logfile, memlines, jsonout=FALSE, verbose = FALSE )  {
         flush(bunyan_globals$log_con)
         close(bunyan_globals$log_con)
       }
-      log_con <- stdout()
+      log_con <- NULL
     }
+  } else if(logfile == "stdout") {
+    log_con <- stdout()
   } else {
     if(missing(logpath)) { # Use Current directory
       if (.Platform$OS.type == "unix") {
@@ -108,8 +110,10 @@ function(level, logpath, logfile, memlines, jsonout=FALSE, verbose = FALSE )  {
     # Create empty log write first line
       log_con <- file(logname,"wt")
     }
+  } else if(logfile == "stdout") {
+    log_con <- stdout()
   } else {
-      log_con <- stdout()
+    log_con <- NULL
   }
 
   # Set up bunyan environment 


### PR DESCRIPTION
To allow for backward compatibility, keep original code and add specific handlers for whenever logname is 'stdout'. This differs from the verbose argument because it outputs the raw log message.
